### PR TITLE
Sobel filter typo fix and other chain order fix

### DIFF
--- a/icarus_signal_processing/Detection/EdgeDetection.cxx
+++ b/icarus_signal_processing/Detection/EdgeDetection.cxx
@@ -204,11 +204,11 @@ void icarus_signal_processing::EdgeDetection::SepSobelRow(const VectorFloat &inp
   const int N = inputRow.size();
 
   // Boundary cases
-  outputRow[0] = -1.0 * inputRow[1];
-  outputRow[N-1] = 1.0 * inputRow[N-2];
+  outputRow[0] = -inputRow[1];
+  outputRow[N-1] = inputRow[N-2];
 
   for (int i=1; i<N-1; ++i) {
-    outputRow[i] = 1.0 * inputRow[i-1] + -1.0 * inputRow[i+1];
+    outputRow[i] = inputRow[i-1] - inputRow[i+1];
   }
 
   return;
@@ -220,11 +220,11 @@ void icarus_signal_processing::EdgeDetection::SepSobelCol(const VectorFloat &inp
   const int N = inputRow.size();
 
   // Boundary cases
-  outputRow[0] = 2.0 * inputRow[0] + 1.0 * inputRow[1];
-  outputRow[N-1] = 2.0 * inputRow[N-1] * 1.0 * inputRow[N-2];
+  outputRow[0] = 2.0 * inputRow[0] + inputRow[1];
+  outputRow[N-1] = 2.0 * inputRow[N-1] + inputRow[N-2];
 
   for (int i=1; i<N-1; ++i) {
-    outputRow[i] = 1.0 * inputRow[i-1] + 1.0 * inputRow[i+1] + 2.0 * inputRow[i];
+    outputRow[i] = inputRow[i-1] + inputRow[i+1] + 2.0 * inputRow[i];
   }
 
   return;

--- a/icarus_signal_processing/ROIFinder2D.cxx
+++ b/icarus_signal_processing/ROIFinder2D.cxx
@@ -329,26 +329,10 @@ void icarus_signal_processing::ROICannyFilter::operator()(const IROIFinder2D::Ar
                   medianVals.begin(),
                   numChannels);
   
-    // 5. Directional Smoothing
-    std::cout << "++> Step 5: Directional smoothing" << std::endl;
-    Array2D<float> sobelX    = Array2D<float>(numChannels, std::vector<float>(numTicks,0.));
-    Array2D<float> sobelY    = Array2D<float>(numChannels, std::vector<float>(numTicks,0.));
-    Array2D<float> gradient  = Array2D<float>(numChannels, std::vector<float>(numTicks,0.));
-    Array2D<float> direction = Array2D<float>(numChannels, std::vector<float>(numTicks,0.));
 
-    fEdgeDetector->SepSobel(waveLessCoherent, sobelX, sobelY, gradient, direction);
+    std::cout << "==> Step 5: Perform Canny Edge Detection" << std::endl;
 
-    std::cout << "==> Step 6: Apply bilateral filter" << std::endl;
-
-    fBilateralFilter->directional(waveLessCoherent, direction, buffer, fADFilter_SX, fADFilter_SY, fSigma_x, fSigma_y, fSigma_r, 360);
-
-    std::cout << "==> Step 7: Apply Second Morphological Enhancing" << std::endl;
-
-    Dilation2D(fADFilter_SX,fADFilter_SY)(buffer.begin(), numChannels, buffer.begin());
-
-    std::cout << "==> Step 8: Perform Canny Edge Detection" << std::endl;
-
-    // 6. Apply Canny Edge Detection
+    // 5. Apply Canny Edge Detection
     fEdgeDetector->Canny(buffer, rois, fADFilter_SX, fADFilter_SY,
                          fSigma_x, fSigma_y, fSigma_r,
                          fLowThreshold, fHighThreshold, 'd');  // Since we run on deconvolved waveforms, use dilation 


### PR DESCRIPTION
Now the ROI reconstruction chain should be in the same order as that of my python interface. 