### PR TITLE
Fast Hysteresis Thresholding for Canny

### DIFF
--- a/icarus_signal_processing/Detection/DisjointSetForest.cxx
+++ b/icarus_signal_processing/Detection/DisjointSetForest.cxx
@@ -1,0 +1,65 @@
+#ifndef __SIGPROC_TOOLS_DISJOINTSETFOREST_CXX__
+#define __SIGPROC_TOOLS_DISJOINTSETFOREST_CXX__
+
+#include "DisjointSetForest.h"
+
+
+int icarus_signal_processing::DisjointSetForest::Find(int x) 
+{
+    if (x == parent[x]) return x;
+    else {
+        int rep = Find(parent[x]);
+        parent[x] = rep; // Path compression
+        return rep;
+    }
+}
+
+void icarus_signal_processing::DisjointSetForest::MakeSet()
+{
+    for (int i=0; i< (int) size; ++i) {
+        parent[i] = i;
+    }
+    return;
+}
+
+void icarus_signal_processing::DisjointSetForest::MakeSet(std::vector<int>& strongEdges)
+{
+    if (strongEdges.size() < 1) {
+        std::string msg = "When constructing disjoint set parent with list of root "
+                          "set members, list must contain at least one entry. Returning";
+        std::cout << msg << std::endl;
+        return;
+    }
+    int root = strongEdges[0];
+
+    for (int i=0; i< (int) size; ++i) {
+        parent[i] = i;
+    }
+
+    for (int& x : strongEdges) {
+        parent[x] = root;
+    }
+    return;
+}
+
+void icarus_signal_processing::DisjointSetForest::Union(int x, int y)
+{
+    int repX = Find(x);
+    int repY = Find(y);
+
+    if (repX == repY) return;
+
+    else {
+        int rankX = rank[repX];
+        int rankY = rank[repY];
+
+        if (rankX < rankY) parent[repX] = repY;
+        else if (rankX > rankY) parent[repY] = repX;
+        else {
+            parent[repX] = repY;
+            rank[repY] = rank[repY] + 1;
+        }
+    }
+} 
+
+#endif

--- a/icarus_signal_processing/Detection/DisjointSetForest.h
+++ b/icarus_signal_processing/Detection/DisjointSetForest.h
@@ -1,0 +1,59 @@
+/**
+ * \file DisjointSetForest.h
+ *
+ * \ingroup sigproc_tools
+ * 
+ * \brief Class def header for a class DisjointSetForest
+ *
+ * @author koh0207
+ */
+
+/** \addtogroup sigproc_tools
+
+    @{*/
+#ifndef __SIGPROC_TOOLS_DISJOINTSETFOREST_H__
+#define __SIGPROC_TOOLS_DISJOINTSETFOREST_H__
+
+#include <vector>
+#include <iostream>
+#include <string>
+
+namespace icarus_signal_processing {
+
+  /**
+     \class DisjointSetForest
+     User defined class DisjointSetForest ... these comments are used to generate
+     doxygen documentation!
+  */
+
+  class DisjointSetForest{
+    
+    public:
+      
+      /// Default constructor
+      DisjointSetForest(const unsigned int size) {
+        parent.resize(size+1);
+        rank.resize(size+1);
+        this->size = size+1;
+      }
+      
+      /// Default destructor
+      ~DisjointSetForest(){}
+
+      std::vector<int> parent;
+      std::vector<int> rank;
+      size_t size = 0;
+
+      void MakeSet();
+
+      void MakeSet(std::vector<int>& strongEdges);
+
+      void Union(int x, int y);
+
+      int Find(int x);
+  };
+}
+
+#endif
+/** @} */ // end of doxygen group 
+

--- a/icarus_signal_processing/Detection/EdgeDetection.h
+++ b/icarus_signal_processing/Detection/EdgeDetection.h
@@ -24,6 +24,8 @@
 #include <assert.h>
 #include <queue>
 
+#include "DisjointSetForest.h"
+
 namespace icarus_signal_processing
 {
 
@@ -143,6 +145,12 @@ namespace icarus_signal_processing
         const std::vector<int> &weakEdgeRows,
         const std::vector<int> &weakEdgeCols,
         Array2D<bool> &output2D) const;
+
+    void HysteresisThresholdingFast(
+        const Array2D<float> &doneNMS2D,
+        float lowThreshold,
+        float highThreshold,
+        Array2D<bool>& outputROI) const;
 
     void Canny(
         const Array2D<float> &waveLessCoherent,

--- a/icarus_signal_processing/Detection/LinkDef.h
+++ b/icarus_signal_processing/Detection/LinkDef.h
@@ -14,6 +14,7 @@
 #pragma link C++ class icarus_signal_processing::Detection::MorphologicalFunctions1D+;
 #pragma link C++ class icarus_signal_processing::Detection::MorphologicalFunctions2D+;
 #pragma link C++ class icarus_signal_processing::Detection::Thresholding+;
+#pragma link C++ class icarus_signal_processing::Detection::DisjointSetForest+;
 //ADD_NEW_CLASS ... do not change this line
 #endif
 


### PR DESCRIPTION
This is a better implementation of double+hysteresis thresholding which is ~100x faster (at least in CPU w/o multithreading)

Old:
```
18.8 s ± 157 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

New:
```
176 ms ± 11.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Here `EdgeDetection::Canny` is modified to use the faster version. 