### PR TITLE
Fixed indexing and tree construction issues

### DIFF
--- a/icarus_signal_processing/Detection/DisjointSetForest.cxx
+++ b/icarus_signal_processing/Detection/DisjointSetForest.cxx
@@ -4,7 +4,7 @@
 #include "DisjointSetForest.h"
 
 
-int icarus_signal_processing::DisjointSetForest::Find(int x) 
+int icarus_signal_processing::DisjointSetForest::Find(const int x) 
 {
     if (x == parent[x]) return x;
     else {
@@ -22,7 +22,7 @@ void icarus_signal_processing::DisjointSetForest::MakeSet()
     return;
 }
 
-void icarus_signal_processing::DisjointSetForest::MakeSet(std::vector<int>& strongEdges)
+void icarus_signal_processing::DisjointSetForest::MakeSet(const std::vector<int>& strongEdges)
 {
     if (strongEdges.size() < 1) {
         std::string msg = "When constructing disjoint set parent with list of root "
@@ -36,28 +36,39 @@ void icarus_signal_processing::DisjointSetForest::MakeSet(std::vector<int>& stro
         parent[i] = i;
     }
 
-    for (int& x : strongEdges) {
+    for (const int& x : strongEdges) {
         parent[x] = root;
     }
     return;
 }
 
-void icarus_signal_processing::DisjointSetForest::Union(int x, int y)
+void icarus_signal_processing::DisjointSetForest::Union(const int x, const int y)
 {
     int repX = Find(x);
     int repY = Find(y);
 
     if (repX == repY) return;
 
+    else if (repX == (int) (size-1)) parent[repY] = repX;
+
+    else if (repY == (int) (size-1)) parent[repX] = repY;
+
     else {
         int rankX = rank[repX];
         int rankY = rank[repY];
 
-        if (rankX < rankY) parent[repX] = repY;
-        else if (rankX > rankY) parent[repY] = repX;
+        if (rankX < rankY) {
+            parent[repX] = repY;
+            // std::cout << repX << " -> " << repY << std::endl;
+        }
+        else if (rankX > rankY) {
+            parent[repY] = repX;
+            // std::cout << repY << " -> " << repX << std::endl;
+        }
         else {
             parent[repX] = repY;
             rank[repY] = rank[repY] + 1;
+            // std::cout << repX << " -> " << repY << std::endl;
         }
     }
 } 

--- a/icarus_signal_processing/Detection/DisjointSetForest.h
+++ b/icarus_signal_processing/Detection/DisjointSetForest.h
@@ -46,11 +46,11 @@ namespace icarus_signal_processing {
 
       void MakeSet();
 
-      void MakeSet(std::vector<int>& strongEdges);
+      void MakeSet(const std::vector<int>& strongEdges);
 
-      void Union(int x, int y);
+      void Union(const int x, const int y);
 
-      int Find(int x);
+      int Find(const int x);
   };
 }
 

--- a/icarus_signal_processing/Detection/EdgeDetection.h
+++ b/icarus_signal_processing/Detection/EdgeDetection.h
@@ -150,8 +150,8 @@ namespace icarus_signal_processing
 
     void HysteresisThresholdingFast(
         const Array2D<float> &doneNMS2D,
-        float lowThreshold,
-        float highThreshold,
+        const float lowThreshold,
+        const float highThreshold,
         Array2D<bool>& outputROI) const;
 
     void Canny(


### PR DESCRIPTION

`skimage.filters.apply_hysteresis_threshold` (comparison, on ~3000x4000 array):
```
259 ms ± 444 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

New (on ~3000x4000 array):
```
227 ms ± 5.67 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

skimage uses + shaped 4-neighborhood for merging while the `EdgeDetection` uses a 3x3 square 8-neighborhood, so the results will not be exactly the same. 