### PR TITLE
Updating the coherent noise subtraction - optimizing for 64 channels

### DIFF
--- a/icarus_signal_processing/Denoising.h
+++ b/icarus_signal_processing/Denoising.h
@@ -67,8 +67,10 @@ public:
                              const unsigned int,
                              const unsigned int ) const;
     
-    float getMedian(      std::vector<float>&, const unsigned int) const;
-    float getMostProbable(std::vector<float>&, const unsigned int) const;
+    float getMedian(        std::vector<float>::iterator, std::vector<float>::iterator) const;
+    float getMostProbable(  std::vector<float>::iterator, std::vector<float>::iterator) const;
+    float getMode(          std::vector<float>::iterator, std::vector<float>::iterator) const;
+    float getIteratedMedian(std::vector<float>::iterator, std::vector<float>::iterator, int&, int&) const;
 
 private:
     // The code for the most probable calculation will need a std vector


### PR DESCRIPTION
For ICARUS there is less decimation of signal if we use 64 channels for coherent noise subtraction.This corresponds to the 64 channel group on a readout board. Note that this group splits into 2 groups of 32 channels. There is a bit of a difference in coherence between these two groups but there seems to be no good solution on signal decimation with 32 channels. On the other hand, the two groups of 32 have separation in channel space - for the middle induction and collection they are separate planes, for the first induction they are split groups. So this works "better" in that it almost does away with signal decimation but at the expense of a bit more remnant noise in the image. Hopefully a hardware solution will be found. 