### PR TITLE
Feature/usher pcacoherentnoise

### DIFF
--- a/icarus_signal_processing/Denoising.h
+++ b/icarus_signal_processing/Denoising.h
@@ -92,13 +92,31 @@ public:
     float getIteratedMean(  std::vector<float>::iterator, std::vector<float>::iterator, float) const;
     float getTruncatedMean( std::vector<float>::iterator, std::vector<float>::iterator, float) const;
 
-    bool  getPredictedCorrections(const PointCloud<float>&, const WavePoint<float>&, const Eigen::Matrix2f&, float, float, VectorFloat&) const;
+    void  getIteratedPCAEllipse(PointCloud<float>&, Eigen::Vector<float,2>&, Eigen::Matrix<float,2,2>&, Eigen::Vector<float,2>&, const float&, const float&) const;
+    void  getIteratedPCAAxis(   PointCloud<float>&, Eigen::Vector<float,2>&, Eigen::Matrix<float,2,2>&, Eigen::Vector<float,2>&, const float&) const;
+    void  getGroupedPCA(        PointCloud<float>&, Eigen::Vector<float,2>&, Eigen::Matrix<float,2,2>&, Eigen::Vector<float,2>&, const float&) const;
+
+    bool  getPredictedCorrections(const PointCloud<float>&, const WavePoint<float>&, const Eigen::Matrix2f&, float, float, PointCloud<float>&)  const;
+
+    struct CandSignals
+    {
+        short index;        // tick index of candidate signal
+        short hiLoIdx;      // which grouping?
+        float significance; // ratio of point magnitude ellipse boundary
+    };
+
+    using CandSignalResultVec = std::vector<CandSignals>;
+
+    void  getCandSignalIndicesEllipse( const PointCloud<float>&, const WavePoint<float>&, const Eigen::Matrix2f&, float, float, CandSignalResultVec&) const;
+    void  getCandSignalIndicesCylinder(const PointCloud<float>&, const WavePoint<float>&, const Eigen::Matrix2f&, float, float, CandSignalResultVec&) const;
+
+    const float nEigenValues = 3.5;
 
 private:
     // The code for the most probable calculation will need a std vector
     // We don't wnat to allocated/deallocate each call so have master copy here
     mutable std::vector<int> fMPVec;
-   // bool                     fOutputStats;
+    // bool                     fOutputStats;
   
 };
 
@@ -124,6 +142,7 @@ public:
                             ArrayFloat::iterator,
                             FilterFunctionVec::const_iterator,
                             const VectorFloat&,
+                            const VectorInt&,
                             const unsigned int,
                             const unsigned int,
                             const unsigned int,
@@ -167,6 +186,7 @@ public:
                     ArrayFloat::iterator,
                     FilterFunctionVec::const_iterator,
                     const VectorFloat&,
+                    const VectorInt&,
                     const unsigned int,
                     const unsigned int,
                     const unsigned int,
@@ -191,6 +211,7 @@ public:
                     ArrayFloat::iterator,
                     FilterFunctionVec::const_iterator,
                     const VectorFloat&,
+                    const VectorInt&,
                     const unsigned int,
                     const unsigned int,
                     const unsigned int,
@@ -215,6 +236,7 @@ public:
                     ArrayFloat::iterator,
                     FilterFunctionVec::const_iterator,
                     const VectorFloat&,
+                    const VectorInt&,
                     const unsigned int,
                     const unsigned int,
                     const unsigned int,
@@ -239,6 +261,7 @@ public:
                     ArrayFloat::iterator,
                     FilterFunctionVec::const_iterator,
                     const VectorFloat&,
+                    const VectorInt&,
                     const unsigned int,
                     const unsigned int,
                     const unsigned int,
@@ -262,6 +285,7 @@ public:
                     ArrayFloat::iterator,
                     FilterFunctionVec::const_iterator,
                     const VectorFloat&,
+                    const VectorInt&,
                     const unsigned int,
                     const unsigned int,
                     const unsigned int,


### PR DESCRIPTION
Here we are adding an alternative method for handling the coherent noise. This tries to be more sensitive to potential signal in the calculation of the medians in three ways:

1.  We limit the calculation of the median to 24 of 42 channels, eliminating the lowest 4 and hightest 4 outliers.
2.  We used the range of ADC values from the above to discriminate between the medians calculated in the two groups of 32 common to a readout board. Essentially we plot each pair's ADC ranges for all 4096 ticks, the use an iterated PCA approach to find the circle containing the median values with no signal on them. For the outliers we can use the median value in the pair that would still be contained within the circle.
3.   The final step is to compare the medians themselves for each pair over 4096 ticks. Here we cannot unambiguously determine which median contains signal so the fallback position is to determine which is smallest and assume that is correct. 

A more complete description can be found in this [writeup ](https://sbn-docdb.fnal.gov/cgi-bin/sso/RetrieveFile?docid=38155&filename=Updates%20on%20Coherent%20Noise%20Removal.pdf&version=1)in docdb. 

